### PR TITLE
bugfix: close workers at end of call

### DIFF
--- a/argon2pure.py
+++ b/argon2pure.py
@@ -140,6 +140,10 @@ def argon2(password, salt, time_cost, memory_cost, parallelism,
                 for index in range(segment_length):
                     B[i][segment * segment_length + index] = new_blocks[index]
 
+    if worker_pool:
+        # don't let workers sit around until pool is GC'd
+        worker_pool.close()
+
     B_final = b'\0' * 1024
 
     for i in range(parallelism):

--- a/test_argon2pure.py
+++ b/test_argon2pure.py
@@ -36,6 +36,12 @@ class TestArgon(unittest.TestCase):
             memory_cost = 16 + (4 ** exponent)
             self._test(2, memory_cost, 2)
 
+    # def test_heavy_load(self):
+    #     # make sure pool workers are cleaned up after call,
+    #     # so they don't accumulate until pool is GC'ed
+    #     for _ in range(200):
+    #         argon2(b"p", b"s", time_cost=1, memory_cost=16, parallelism=2)
+
 class TestBlake2b(unittest.TestCase):
     def test_blake2b_keyed(self):
         cur = b'!'


### PR DESCRIPTION
I _think_ this fixes the memory usage issue I was observing.

The pool wasn't being explicitly closed, so the worker processes were left around until the pool was garbage collected.   Which meant if you had a few hundred argon2() calls before the garbage collector had a chance to run, all those processes would stay around.  

This adds a fix, and also a unittest which I was using to replicate the issue. (Unittest is commented out because I figured you might not want to have it run in general, takes a little while to run). 
