### PR TITLE
Fix usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Usage
 
     >>> import argon2pure
     >>> from binascii import hexlify
-    >>> hexlify(argon2pure.argon2('password', 'randomsalt', time_cost=1, memory_cost=16, parallelism=2))
+    >>> hexlify(argon2pure.argon2(b'password', b'randomsalt', time_cost=1, memory_cost=16, parallelism=2))
     '0163c5fa892819055eb07b8acb94fd2ff5273e689b34107daaaaceda648f1e1b'
 
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Usage
     >>> import argon2pure
     >>> from binascii import hexlify
     >>> hexlify(argon2pure.argon2(b'password', b'randomsalt', time_cost=1, memory_cost=16, parallelism=2))
-    '0163c5fa892819055eb07b8acb94fd2ff5273e689b34107daaaaceda648f1e1b'
+    b'0163c5fa892819055eb07b8acb94fd2ff5273e689b34107daaaaceda648f1e1b'
 
 
 Installation


### PR DESCRIPTION
This

```python
hexlify(argon2pure.argon2('password', 'randomsalt', time_cost=1, memory_cost=16, parallelism=2))
```

gives

```python
TypeError: can't concat str to bytes
```

Changing the inputs to bytes will give the output

```python
b'0163c5fa892819055eb07b8acb94fd2ff5273e689b34107daaaaceda648f1e1b'
```